### PR TITLE
Linear light: Do not use `unspecified` as input matrix/primaries

### DIFF
--- a/getfnative.py
+++ b/getfnative.py
@@ -102,7 +102,7 @@ def gen_descale_error(clip: vs.VideoNode,
     clips = clip[frame_no].resize.Point(
         format=vs.GRAYS, matrix_s='709' if clip.format.color_family == vs.RGB else None) * num_samples
     if ll:
-        clips = core.resize.Point(clips, transfer=8, transfer_in=1)
+        clips = core.resize.Point(clips, transfer=8, matrix_in=1, transfer_in=1, primaries_in=1)
     # Descale
     def _rescale(n: int, clip: vs.VideoNode) -> vs.VideoNode:
         cropping_args = descale_cropping_args(


### PR DESCRIPTION
If you run this on a `.vpy` script, you may get an error like this right now:

```vapoursynth.Error: Resize error: Resize error 3074: no path between colorspaces (2/1/2 => 2/8/2). May need to specify additional colorspace parameters.```

To fix this, we need to tell VS about our input matrix, transfer and primaries (`transfer_in` is already set at least), so I've hardcoded it to `BT.709` matrix/primaries since that's what the input transfer is already.

Thankfully, it doesn't seem to matter what we specify as input since unless we explicitly set the output colorspace args, it'll default to the clip inputs, so this should work just fine.